### PR TITLE
Update largest connected component logic

### DIFF
--- a/nefi2/model/algorithms/largest_connected.py
+++ b/nefi2/model/algorithms/largest_connected.py
@@ -46,9 +46,8 @@ class AlgBody(Algorithm):
         """
         image_arr, graph = args[0:2]
         try:
-            graph = max(nx.connected_component_subgraphs(graph), key=len)
-            # supposedly slower
-            # graph = list(nx.connected_components(graph))[0]
+            subgraph_nodes = max(nx.connected_components(graph), key=len)
+            graph = graph.subgraph(subgraph_nodes).copy()
         except ValueError as e:
             print('ValueError exception:', e)
         self.result['graph'], self.result['img'] = graph, image_arr


### PR DESCRIPTION
**Why?**
Version 2.4 of networkx deprecated the connected_component_subgraphs
method, see announcement here: https://networkx.github.io/documentation/stable/release/release_2.4.html

This breaks the LargestConnected pipeline step.

**This change addresses the need by:**
Updating to use the connected_components method per the documentation here:
https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.connected_components.html?highlight=connected_component