### PR TITLE
Making NEFI compatible with recent versions of python3/libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,29 @@ You don't need to write tons of boilerplate code, reimplement existing UI widget
 
 ##### Linux
 
-* Make sure you have your **Python 3.4/3.5** installed before performing the steps below.
+* Make sure you have your **Python 3.8** installed before performing the steps below.
 * Install **PyQt5** using your default package manager.
-* Next, you'll need to compile **OpenCV 3.1.0** for your Python 3.
+* Install **opencv-python** via pip:
+
+```
+pip install opencv-python
+```
+
+Depending on your distrbution, you may need to replace the `pip` command by `pip3`.
+
+Next, clone the github repository and run the installation script.
+
+* `git clone https://github.com/05dirnbe/nefi.git`
+* `cd nefi`
+* `./linux_install.sh`
+
+If everything goes well, you can run **NEFI2** by typing `nefi2` in the console.
+
+
+##### Compiling OpenCV (deprecated)
+
+If you decide not to install OpenCV via pip, you can try to compile **OpenCV 3.1.0** for your Python 3.
+Note that these instructions are most likely outdated and will no longer work.
 
 ```
     git clone https://github.com/Itseez/opencv.git
@@ -31,11 +51,6 @@ You don't need to write tons of boilerplate code, reimplement existing UI widget
     sudo make install
 ```
 
-* `git clone https://github.com/05dirnbe/nefi.git`
-* `cd nefi`
-* `./linux_install.sh`
-
-If everything goes well, you can run **NEFI2** by typing in console `nefi2`.
 Note: If your Linux installation uses `python` instead of `python3` to call your python 3 interepreter, you have to replace `python3` with just `python` for the OpenCV installation. It should look like this:
 
 ```

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Depending on your distrbution, you may need to replace the `pip` command by `pip
 
 Next, clone the github repository and run the installation script.
 
-* `git clone https://github.com/05dirnbe/nefi.git`
-* `cd nefi`
-* `./linux_install.sh`
+```
+git clone https://github.com/05dirnbe/nefi.git
+cd nefi
+./linux_install.sh
+```
 
 If everything goes well, you can run **NEFI2** by typing `nefi2` in the console.
 

--- a/nefi2/main.py
+++ b/nefi2/main.py
@@ -14,10 +14,11 @@ from nefi2.view.main_controller import MainView
 import sys
 import argparse
 import ctypes
-from PyQt5 import QtGui
+from PyQt5 import QtGui, QtCore
 from PyQt5.QtWidgets import QApplication
 import qdarkstyle
 
+os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 
 __authors__ = {"Pavel Shkadzko": "p.shkadzko@gmail.com",
                "Dennig Groß": "gdennis91@googlemail.com",
@@ -37,6 +38,7 @@ class Main:
         extloader = ExtensionLoader()
         pipeline = Pipeline(extloader.cats_container)
         app = QApplication(sys.argv)
+        app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
         app.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
         app.setQuitOnLastWindowClosed(True)
         app.setWindowIcon(QtGui.QIcon(os.path.join('icons', 'nefi2.ico')))

--- a/nefi2/model/algorithms/largest_connected.py
+++ b/nefi2/model/algorithms/largest_connected.py
@@ -46,7 +46,8 @@ class AlgBody(Algorithm):
         """
         image_arr, graph = args[0:2]
         try:
-            graph = max(nx.connected_component_subgraphs(graph), key=len)
+            ccs = (graph.subgraph(c) for c in nx.connected_components(graph))
+            graph = max(ccs, key=len).copy()
             # supposedly slower
             # graph = list(nx.connected_components(graph))[0]
         except ValueError as e:

--- a/nefi2/model/algorithms/thinning_alg.py
+++ b/nefi2/model/algorithms/thinning_alg.py
@@ -14,6 +14,7 @@ import cv2
 import networkx as nx
 import numpy as np
 import thinning
+from thinning import guo_hall_thinning
 import sys
 import traceback
 from collections import defaultdict
@@ -47,7 +48,7 @@ class AlgBody(Algorithm):
 
         """
         # create a skeleton
-        skeleton = thinning.guo_hall_thinning(args[0].copy())
+        skeleton = guo_hall_thinning(args[0].copy())
         #skeleton = cv2.cvtColor(skeleton, cv2.COLOR_GRAY2BGR)
         self.result['skeleton'] = skeleton
         self.result['img'] = args[0]


### PR DESCRIPTION
First of all, thank you for this great piece of software.

Some of the code is not compatible anymore with recent versions of python and the networkx library, as well as with modern High-DPI monitors.

This pull-request

* Adds compatibility with recent NetworkX 2.5
* Adds compatibility with HighDPI monitors (only tested on Linux)
* Adds compatibility with recent versions of Python by asking the user to install the `opencv-python` package via `pip`, instead of manually compiling OpenCV (the version recommended will not compile with Python 3.8 for instance.)

The code was tested on Linux using all pipelines included by default and appears to fine.